### PR TITLE
chore(deps): update nativescript-imagepicker version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "3.4.6",
     "everlive-sdk": "1.9.2",
     "nativescript-angular": "1.4.0",
-    "nativescript-imagepicker": "2.5.0",
+    "nativescript-imagepicker": "~2.5.1",
     "nativescript-permissions": "^1.2.0",
     "nativescript-push-notifications": "0.1.2",
     "nativescript-telerik-ui": "next",


### PR DESCRIPTION
New version (2.5.1) with fix for AoT support was published